### PR TITLE
Revert "otaniemi.yml: use official name, make colloquialism an alias"

### DIFF
--- a/otaniemi.yml
+++ b/otaniemi.yml
@@ -555,8 +555,7 @@ buildings:
     aliases: [R040, Urdsgjallar]
     label: TF
     children:
-      - name: Teknologföreningen
-        aliases: [Täffä]
+      - name: Täffä
         type: restaurant
         osm: node=580707759
         lore: >-


### PR DESCRIPTION
The official name of the restaurant is in fact Täffä [1].

 [1] https://about.teknologforeningen.fi/index.php/dagsrestaurangen

This reverts commit 72b099d156ec0f6bf8bff113d21680f75f4ecd25.