### PR TITLE
Proof of concept of static routes / "how to get here"

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,8 +98,14 @@ angular.module('usefulAaltoMap', ['ui-leaflet', 'ui.router', 'ngMaterial'])
   .state('app.selectedObject', {
     templateUrl: '/sidenav/sidenav.html',
     controller: 'sidenavController',
-    url: '/select/:objectId',
+    url: '/select/:objectId/:routeIdx?',
+    params:{
+      routeIdx:""
+    },
     resolve: {
+      routeIdx: function($stateParams) {
+        return($stateParams.routeIdx);
+      },
       object: function($stateParams, mapService, $q, $state, $timeout) {
 
         var objId = $stateParams.objectId;

--- a/app.js
+++ b/app.js
@@ -62,6 +62,8 @@ angular.module('usefulAaltoMap', ['ui-leaflet', 'ui.router', 'ngMaterial'])
               })
               // Redirections
               mapService.redirects = res.data.redirects;
+              // Routes
+              mapService.routes = res.data.routes;
               // Add objects to map
               angular.forEach(mapService.data, function(d) {
                 switch (d.type) {

--- a/app.js
+++ b/app.js
@@ -100,11 +100,14 @@ angular.module('usefulAaltoMap', ['ui-leaflet', 'ui.router', 'ngMaterial'])
     controller: 'sidenavController',
     url: '/select/:objectId/:routeIdx?',
     params:{
-      routeIdx:""
+      routeIdx:{
+        value:null,
+        squash:true
+      }
     },
     resolve: {
       routeIdx: function($stateParams) {
-        return($stateParams.routeIdx);
+        return({value:$stateParams.routeIdx});
       },
       object: function($stateParams, mapService, $q, $state, $timeout) {
 

--- a/compile.py
+++ b/compile.py
@@ -439,6 +439,7 @@ for R in routes:
 if use_cache and os.path.exists('osm_raw_data.json'):
     r = json.loads(open('osm_raw_data.json').read())
 else:
+    assert all(map(lambda x: len(x)==2,osm_ways)), "some osm_ways not of form ['type','id']: %s" % str(list(filter(lambda x:len(x)!=2,osm_ways)))
     rquery = [ '%s(%s)%s'%(t,osmid, ';>' if t=='way' else '') for t, osmid in osm_ways ]
     rquery.append('node(60.1823,24.81394,60.1906,24.8338)[amenity=printer]')
     rquery.append('node(60.1823,24.81394,60.1906,24.8338)[room]')

--- a/compile.py
+++ b/compile.py
@@ -355,32 +355,33 @@ class Route():
     @property
     def osm_data_location(self):
         """OSM elements that have the location data (path or latlon)"""
-        #TODO: split by stage
         osm_elements = [ ]
         for S in self.data["stages"]:
             if 'osm' in S:
                 if isinstance(S['osm'], str) and ',' in S['osm']:
                   parts=S["osm"].split(",")
                   parts=list(map(lambda part: osm_data[int(part.split('=')[1])],parts))
-                  osm_elements.extend(parts)
+                  osm_elements.append(parts)
                 elif isinstance(S['osm'], str) and '=' in S['osm']:
-                    osm_elements.append(int(S['osm'].split('=')[1]))
+                    osm_elements.append([osm_data[int(S['osm'].split('=')[1])]])
                 else:
-                    osm_elements.append(osm_data[self.data['osm']])
+                    osm_elements.append([osm_data[self.data['osm']]])
         if osm_elements:
             return osm_elements
         return None
     @property
     def outline(self):
-        locdat_all = self.osm_data_location
         path=[]
-        for locdat in locdat_all:
-            if locdat['type'] != 'way':
-                continue
-            if 'nodes' in locdat:
-                nodes = [ (round(osm_data[n]['lat'], 6), round(osm_data[n]['lon'], 6))
-                         for n in locdat['nodes'] ]
-                path.append(nodes)
+        for stage in self.osm_data_location:
+            stage_path=[]
+            for locdat in stage:
+                if locdat['type'] != 'way':
+                    continue
+                if 'nodes' in locdat:
+                    nodes = [ (round(osm_data[n]['lat'], 6), round(osm_data[n]['lon'], 6))
+                             for n in locdat['nodes'] ]
+                    stage_path.append(nodes)
+            path.append(stage_path)
         return path
 
 

--- a/compile.py
+++ b/compile.py
@@ -78,6 +78,7 @@ class Location():
         update_maybe(self.data, 'children', data)
         update_maybe(self.data, 'lore', data)
         update_maybe(self.data, 'note', data)
+        update_maybe(self.data, 'routes', data)
         update_maybe(self.data, 'opening_hours', data)
         update_maybe(self.data, 'ref', data)
         update_maybe(self.data, 'nosearch', data)
@@ -311,6 +312,78 @@ class Location():
         return (0, self.data.get('name', ''))
 
 
+# Class for routes to Locations
+class Route():
+    """Holds routes composed of OSM ways and nodes"""
+    def __init__(self, loc, routeIdx,type=None, parent=None):
+        self.targetLocation = loc
+        self.routeIdx=routeIdx
+        self.data=self.targetLocation.data['routes'][self.routeIdx]
+    def __repr__(self):
+        return '%s(objectid=%s,routeIdx=%d)'%(self.__class__.__name__, self.id,self.routeIdx)
+    @property
+    def id(self):
+        return str(self.targetLocation.id)+"_"+str(self.routeIdx)
+    def json(self):
+        data= dict(
+            objectId=self.targetLocation.id,
+            routeIdx=self.routeIdx
+            )
+        if self.outline: data['outline'] = self.outline
+        if self.osm_elements():
+            data['osm_elements'] = [(t.replace('rel', 'relation'), v)
+                                    for t,v in self.osm_elements()]
+        return data
+
+    # Getter methods
+    def osm_elements(self):
+        """Used when downloading OSM data"""
+        osm_elements = [ ]
+        for S in self.data["stages"]:
+            if 'osm' in S:
+                if isinstance(S['osm'], str) and ',' in S['osm']:
+                  parts=S["osm"].split(",")
+                  parts=list(map(lambda part: part.split('='),parts))
+                  osm_elements.extend(parts)
+                elif isinstance(S['osm'], str) and '=' in S['osm']:
+                    osm_elements.append(S['osm'].split('='))
+                else:
+                    osm_elements.append(('way', S['osm']))
+        if osm_elements:
+            return osm_elements
+        return None
+    @property
+    def osm_data_location(self):
+        """OSM elements that have the location data (path or latlon)"""
+        #TODO: split by stage
+        osm_elements = [ ]
+        for S in self.data["stages"]:
+            if 'osm' in S:
+                if isinstance(S['osm'], str) and ',' in S['osm']:
+                  parts=S["osm"].split(",")
+                  parts=list(map(lambda part: osm_data[int(part.split('=')[1])],parts))
+                  osm_elements.extend(parts)
+                elif isinstance(S['osm'], str) and '=' in S['osm']:
+                    osm_elements.append(int(S['osm'].split('=')[1]))
+                else:
+                    osm_elements.append(osm_data[self.data['osm']])
+        if osm_elements:
+            return osm_elements
+        return None
+    @property
+    def outline(self):
+        locdat_all = self.osm_data_location
+        path=[]
+        for locdat in locdat_all:
+            if locdat['type'] != 'way':
+                continue
+            if 'nodes' in locdat:
+                nodes = [ (round(osm_data[n]['lat'], 6), round(osm_data[n]['lon'], 6))
+                         for n in locdat['nodes'] ]
+                path.append(nodes)
+        return path
+
+
 # assemble locations
 locations = [ ]
 for building in data.get('buildings', []):
@@ -343,6 +416,11 @@ for L in locations:
     for L_parent_id in L.data.get('parents', []):
         locations_lookup[L_parent_id].data['children'].append(L.id)
 
+# assemble routes
+routes = [ ]
+for L in locations:
+  for idx,R in enumerate(L.data.get('routes',[])):
+    routes.append(Route(L,idx))
 
 
 # Find the OSM data that needs downloading
@@ -351,6 +429,11 @@ for L in locations:
     osm_data = L.osm_elements()
     if osm_data is not None:
         osm_ways.extend(osm_data)
+for R in routes:
+    osm_data = R.osm_elements()
+    if osm_data is not None:
+        osm_ways.extend(osm_data)
+
 # Download and cache it
 if use_cache and os.path.exists('osm_raw_data.json'):
     r = json.loads(open('osm_raw_data.json').read())
@@ -365,7 +448,7 @@ else:
     if r.status_code != 200:
         print(rcommand)
         raise RuntimeError("HTTP failure: %s %s"%(r.status_code, r.reason))
-    open('osm_raw_data.json', 'w').write(r.text)
+    open('osm_raw_data.json', 'w',encoding='utf-8').write(r.text)
     try:
         r = r.json()
     except:
@@ -481,9 +564,14 @@ for L in locations:
     print(L.id)
     newdata.append(L.json())
 
+newroutedata = {}
+for R in routes:
+    print(R)
+    newroutedata[R.id]=R.json()
 
 newdata = dict(
     locations=newdata,
+    routes=newroutedata,
     redirects=data['redirects'],
     search=[],
     )

--- a/index.html
+++ b/index.html
@@ -145,6 +145,23 @@
         }
       }
 
+      mapS.zoomOnRoute = function(object,routeIdx){
+        mapS.zoomOnObject(object);
+        var rid=object.id+"_"+routeIdx;
+        var outline=mapS.routes[rid].outline;
+        //ui-leaflet does not support - and numbers in id
+        rid=rid.replace("-","_");
+        //TODO:use separate multipolyline for each stage instead, or concatenate in compile.py
+        outline.forEach(function(line,i){
+          mapS.map.paths[rid+"_"+i]={id:rid+"_"+i,data:object.routes[routeIdx],type:"polyline",color:"red",weight:3,latlngs:line.map(function(coords) {
+            return {
+              lat: coords[0],
+              lng: coords[1]
+              }})
+              };
+        });
+      }
+
       mapS.clearHighlights = function() {
         // Remove any current paths which are not in the "default
         // objects" set.

--- a/index.html
+++ b/index.html
@@ -145,20 +145,28 @@
         }
       }
 
-      mapS.zoomOnRoute = function(object,routeIdx){
+      mapS.zoomOnRoute = function(object, routeIdx){
         mapS.zoomOnObject(object);
+        mapS.drawRoute(object,routeIdx);
+      }
+      
+      mapS.drawRoute = function(object, routeIdx, activeStage=0){
         var rid=object.id+"_"+routeIdx;
-        var outline=mapS.routes[rid].outline;
+        var stage_outlines=mapS.routes[rid].outline;
         //ui-leaflet does not support - and numbers in id
         rid=rid.replace("-","_");
-        //TODO:use separate multipolyline for each stage instead, or concatenate in compile.py
-        outline.forEach(function(line,i){
-          mapS.map.paths[rid+"_"+i]={id:rid+"_"+i,data:object.routes[routeIdx],type:"polyline",color:"red",weight:3,latlngs:line.map(function(coords) {
-            return {
-              lat: coords[0],
-              lng: coords[1]
-              }})
-              };
+        stage_outlines.forEach(function(outline,i){
+            var linecol = i==activeStage ? "black" : "#515A5A";
+            var lwd = i==activeStage ? 8 : 5;
+            outline.forEach(function(line,j){
+              mapS.map.paths[rid+"_"+i+"_"+j]={id:rid+"_"+i+"_"+j,type:"polyline",color:linecol,weight:lwd,opacity:0.4,
+              latlngs:line.map(function(coords) {
+                return {
+                  lat: coords[0],
+                  lng: coords[1]
+                  }})
+                };
+            });
         });
       }
 

--- a/otaniemi.yml
+++ b/otaniemi.yml
@@ -88,12 +88,19 @@ buildings:
         name_sv: K flygeln Main
         osm: 540151861
         type: wing
+        routes:
+          - label: From outside
+            stages:
+              - instruction: Use the door to the south of the main entrance, up some exterior stairs
+                osm: way=27496989,way=239853844,node=5034222525
+          - label: From inside (main entrance), via 2nd floor
+            stages:
+              - instruction: Go up the stairs from the Alvari restaurant to the 2nd floor
+                osm: way=44953545,way=44953546
+              - instruction: Follow the corridor through to the end of H wing, down the stairs behind a door on your right
+                osm: way=44953547,way=515500708,way=515500711
         note: >-
-          This wing is almost impossible to find.  From the outside,
-          use the door to the south of the main entrance, (up some
-          exterior stairs).  From the inside, you have to go either up
-          or down from the Alvari restaurant, and connect from either
-          the 0th or 2nd floor.  Good luck!
+          This wing is almost impossible to find. Good luck!
         lore: >-
           Perhaps "K" stands for "Kirjaamo", or the Aalto Registry.
       - id: M

--- a/sidenav/sidenav.html
+++ b/sidenav/sidenav.html
@@ -22,6 +22,20 @@
       <div ng-show="object.aliases && object.aliases.length">
         <b>Aliases:</b> <span ng-repeat="a in object.aliases track by $index">{{a}}{{$last ? '' : ', '}}</span>
       </div>
+      <div style="font-size: 75%" ng-show="object.routes && object.routes.length">
+        <b>Getting here:</b>
+        <div ng-repeat="r in object.routes track by $index" ng-init="$routeIndex = $index">
+          * <a ng-click="routeIdx && routeIdx==$routeIndex  ? goToState('app.selectedObject',{objectId:object.id,routeIdx: ''}) : goToState('app.selectedObject',{objectId:object.id,routeIdx: $routeIndex})" href="">
+            {{r.label}}
+            </a>
+            
+            <div ng-show="routeIdx && routeIdx==$routeIndex" id=route_{{object.id}}_{{$routeIndex}}>
+              <div ng-repeat="s in r.stages track by $index">
+                - {{s.instruction}}
+              </div>
+            </div>
+        </div>
+      </div>
       <div style="font-size: 75%"  ng-show="object.note">
         <b>Note:</b> <span>{{get_lang(object, 'note')}}</span>
       </div>

--- a/sidenav/sidenav.html
+++ b/sidenav/sidenav.html
@@ -31,7 +31,7 @@
             
             <div ng-show="routeIdx && routeIdx==$routeIndex" id=route_{{object.id}}_{{$routeIndex}}>
               <div ng-repeat="s in r.stages track by $index">
-                - {{s.instruction}}
+                - <span ng-mouseover="$parent.selectedStage=$index;highlightStage($index)" ng-click="$parent.selectedStage=$index;highlightStage($index)" ng-style="{'font-weight': $parent.selectedStage==$index ? 'bold' : 'normal','color':$parent.selectedStage==$index ? 'black' : '#515A5A'}">{{s.instruction}}</span>
               </div>
             </div>
         </div>

--- a/sidenav/sidenav.html
+++ b/sidenav/sidenav.html
@@ -25,7 +25,7 @@
       <div style="font-size: 75%" ng-show="object.routes && object.routes.length">
         <b>Getting here:</b>
         <div ng-repeat="r in object.routes track by $index" ng-init="$routeIndex = $index">
-          * <a ng-click="routeIdx && routeIdx==$routeIndex  ? goToState('app.selectedObject',{objectId:object.id,routeIdx: ''}) : goToState('app.selectedObject',{objectId:object.id,routeIdx: $routeIndex})" href="">
+          * <a ng-click="routeIdx && routeIdx==$routeIndex  ? goToState('app.selectedObject',{objectId:object.id,routeIdx: null}) : goToState('app.selectedObject',{objectId:object.id,routeIdx: $routeIndex})" href="">
             {{r.label}}
             </a>
             

--- a/sidenav/sidenav.js
+++ b/sidenav/sidenav.js
@@ -72,5 +72,10 @@ angular.module('usefulAaltoMap')
     return $scope.get_lang(object, 'url');
   }
 
+  $scope.highlightStage = function(activeStage){
+    mapService.drawRoute($scope.object,$scope.routeIdx,activeStage);
+  }
+
+  $scope.selectedStage=0;
 
 })

--- a/sidenav/sidenav.js
+++ b/sidenav/sidenav.js
@@ -5,7 +5,7 @@ angular.module('usefulAaltoMap')
   $scope.objects = mapService.data;
 
   $scope.object = object;
-  $scope.routeIdx = routeIdx;
+  $scope.routeIdx = routeIdx.value === null ? false : routeIdx.value;
 
   $scope.get_lang = utils.get_lang;
 
@@ -29,7 +29,7 @@ angular.module('usefulAaltoMap')
 
   $timeout(function() {
     //TODO: avoid animated menu when changing route
-  	routeIdx ? mapService.zoomOnRoute(object,routeIdx) : mapService.zoomOnObject(object);
+  	routeIdx.value === null ? mapService.zoomOnObject(object) : mapService.zoomOnRoute(object,routeIdx.value);
   	
   	$mdSidenav('left').open();
 

--- a/sidenav/sidenav.js
+++ b/sidenav/sidenav.js
@@ -1,11 +1,11 @@
 angular.module('usefulAaltoMap')
-.controller('sidenavController', function($scope, mapService, $state, $mdSidenav, $timeout, utils, object) {
+.controller('sidenavController', function($scope, mapService, $state, $mdSidenav, $timeout, utils, object, routeIdx) {
 
 
   $scope.objects = mapService.data;
 
   $scope.object = object;
-  
+  $scope.routeIdx = routeIdx;
 
   $scope.get_lang = utils.get_lang;
 
@@ -19,13 +19,17 @@ angular.module('usefulAaltoMap')
   if (name != name_sv && name_sv != name_fi && name_sv != name_en)
     $scope.name_sv = utils.get_lang(object, 'name', 'sv');
 
+  $scope.goToState = function(stateName, params) {
+    $state.go(stateName, params);
+  }
 
   $scope.selectChild = function(id) {
 
   }
 
   $timeout(function() {
-  	mapService.zoomOnObject(object)
+    //TODO: avoid animated menu when changing route
+  	routeIdx ? mapService.zoomOnRoute(object,routeIdx) : mapService.zoomOnObject(object);
   	
   	$mdSidenav('left').open();
 


### PR DESCRIPTION
Not quite ready to be merged yet, but made a PR to allow commenting/somebody else taking over if interested.

Currently notes are being used to textually describe how to get to a location. Instead, we should be able to show step-by-step instructions, with the path highlighted on the map using OSM ways.

I've included an example for K-wing: http://127.0.0.1:8000/#!/select/main-kwing/1

What I'd still like to change:
- By default, first stage of a route would be highlighted, and mousing over/clicking other stages, would show transitions. This is especially helpful for complex indoor routes over multiple levels
- Currently using a workaround for ui-leaflet multipolyline - couldn't get it to work
- Rather than packaging the routes in data.json, might be better to load in a separate file later. The data is already in a separate object with this in mind.
- Avoid changing URLS? locations now have trailing slash
- Need some kind of QA of the data (especially continuity) because edits to OSM might break the path selected
